### PR TITLE
docs: correct CI Node version matrix claim in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ The project uses GitHub Actions for continuous integration and deployment:
 ### Workflows
 
 - **`ci.yml`**: Main CI pipeline that runs on every push and pull request
-  - Tests across Node.js versions 20.x, 22.x, and 24.x
+  - Tests on Node.js 24.x
   - Runs linting, type checking, building, and testing
   - Uploads coverage reports as artifacts
   - Includes security auditing and dependency checking


### PR DESCRIPTION
## Summary
- README claimed CI tests across Node.js 20.x, 22.x, and 24.x, but `.github/workflows/ci.yml` only has `node-version: [24.x]` in its matrix.
- Update the README to reflect the actual matrix.

This is a pure documentation fix — no code changes. Surfaced while reviewing PR #54.

## Test plan
- [ ] CI passes (no code touched, so checks should be trivially green)
- [ ] README diff reads correctly on the rendered page

🤖 Generated with [Claude Code](https://claude.com/claude-code)