### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glypto",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glypto",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glypto",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "type": "module",
   "main": "dist/exports.js",
   "types": "dist/exports.d.ts",


### PR DESCRIPTION
## Summary

- Bumps `package.json` from `0.1.1` → `0.2.0`. Minor (not patch) because two consumer-visible contract changes have landed since v0.1.1:
  - **New `engines.node: ">=24.4.0"`** (#54). v0.1.1 had no `engines` field, so `npm install` on Node <24.4.0 now emits `EBADENGINE` warnings.
  - **`jsdom: ^27 → ^29`** (#54). Two-major jump on a runtime dep that the README example tells consumers to pair with directly.
- No behavior change in `src/` — the only source diff since v0.1.1 is a Prettier reflow of dynamic-import lines in `provider-loader.ts`. Everything else is dev-only (eslint v10, vitest, @types/*, CI action bumps, docs).
- Not 1.0.0 — there's no signal in recent work that the API is being declared stable.

After merge, tag `v0.2.0` on `main` and push the tag. `release.yml` will run tests, build, create the GitHub Release, and `npm publish`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 155/155 pass
- [x] `npm pack --dry-run` — tarball includes `dist/`, `bin/`, `README.md`, `LICENSE`; declares `version: 0.2.0`
- [ ] CI green on this PR
- [ ] After merge: tag `v0.2.0` triggers `release.yml`, GitHub Release published, `npm view glypto version` returns `0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)