### PR TITLE
chore: add repository metadata for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,14 @@
   "author": "Alvin Crespo",
   "license": "MIT",
   "description": "An experiment using TypeScript to scrape <meta> tags.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alvincrespo/glypto.git"
+  },
+  "bugs": {
+    "url": "https://github.com/alvincrespo/glypto/issues"
+  },
+  "homepage": "https://github.com/alvincrespo/glypto#readme",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@tsconfig/node24": "^24.0.1",


### PR DESCRIPTION
## Summary

Required for npm Trusted Publishing to succeed. The v0.2.0 publish run failed with:

\`\`\`
422 Unprocessable Entity - PUT https://registry.npmjs.org/glypto
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match "https://github.com/alvincrespo/glypto" from provenance
\`\`\`

The OIDC provenance attestation embeds the GitHub repo URL; npm validates that against \`package.json.repository.url\` before accepting the publish. Adding the field unblocks the next publish attempt.

Also added \`bugs\` and \`homepage\` while here — both improve the npm package page.

## Test plan

- [x] \`npm install\` clean
- [x] \`npm run build\` clean
- [x] \`npm test\` 155/155 pass
- [ ] After merge: re-tag v0.2.0 (or bump to v0.2.1) so the release workflow re-runs against the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)