### PR TITLE
release: v0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glypto",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glypto",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glypto",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "main": "dist/exports.js",
   "types": "dist/exports.d.ts",


### PR DESCRIPTION
Bumps version `0.2.0 → 0.2.1`. Merging this unblocks tagging `v0.2.1`, which triggers `release.yml` to publish glypto@0.2.1 to npm via OIDC Trusted Publishing.

CI must be green before merge.