### PR TITLE
refactor: rename release-preflight skill to axc-cut-release-preflight

### DIFF
--- a/.claude/skills/axc-cut-release-preflight/SKILL.md
+++ b/.claude/skills/axc-cut-release-preflight/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: release-preflight
+name: axc-cut-release-preflight
 description: Run safety checks before tagging a glypto release. Validates that the repo, package.json, and release.yml are in a state where pushing a `vX.Y.Z` tag will result in a successful npm publish via Trusted Publishing. Read-only — never modifies files or git state.
 ---
 

--- a/.claude/skills/axc-cut-release/SKILL.md
+++ b/.claude/skills/axc-cut-release/SKILL.md
@@ -65,7 +65,7 @@ This phase ends in an **irreversible npm publish**. It must run preflight and ge
 1. Be on `main`, clean, and up to date:
    - `git checkout main && git pull --ff-only origin main`
    - Confirm `package.json.version == V`. If not, something's off (PR not merged, or wrong `V`) — stop and explain.
-2. **Run the `release-preflight` skill** with version `V`. It validates git state, `package.json`, `release.yml`, and the local build/test/pack. Proceed only on a green (✅) verdict. On 🟡, surface the warnings and ask the user whether to continue. On ❌, stop.
+2. **Run the `axc-cut-release-preflight` skill** with version `V`. It validates git state, `package.json`, `release.yml`, and the local build/test/pack. Proceed only on a green (✅) verdict. On 🟡, surface the warnings and ask the user whether to continue. On ❌, stop.
 3. **Confirm with the user** before pushing — name the consequence explicitly:
    > Pushing `v<V>` triggers `release.yml`, which publishes glypto@<V> to npm. This can't be undone. Push the tag?
 4. On yes:


### PR DESCRIPTION
Renames the `release-preflight` skill to `axc-cut-release-preflight` so it shares the naming prefix of the `axc-cut-release` skill that invokes it.

- `git mv` of the skill directory (rename tracked, 99% similarity)
- Updated `name:` frontmatter in the skill
- Updated the cross-reference in `axc-cut-release/SKILL.md` (Phase 2, step 2)

No behavior change — docs/skill metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)