### PR TITLE
fix(deps): bump brace-expansion to 5.0.9 to clear high-severity advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1899,16 +1899,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/chai": {


### PR DESCRIPTION
## Description
The **Security Audit** CI job is failing on every open PR. `npm audit --audit-level moderate` exits non-zero because `brace-expansion@5.0.6` is covered by two high-severity DoS advisories:

- [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) — DoS via exponential-time expansion of consecutive non-expanding `{}` groups
- [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) — DoS via unbounded expansion length causing an out-of-memory process crash

Both affect `3.0.0 - 5.0.7`. The package reaches us as a transitive **dev** dependency:

```
glypto@0.2.1
└─┬ eslint@10.7.0
  └─┬ minimatch@10.2.5
    └── brace-expansion@5.0.6
```

Because `minimatch`'s range already permits the patched release, `npm audit fix` resolves it to `5.0.9` with a lockfile-only change — no `overrides` entry in `package.json` is needed, so there is nothing to unwind later.

This is what is blocking #82 (`actions/labeler` 6 → 7) and #83 (`chalk` 5.6.2 → 6.0.0); both pass every other check. Once this merges and those two rebase, they should go green.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Bump `brace-expansion` `5.0.6` → `5.0.9` in `package-lock.json`
- No `package.json` changes; no runtime dependencies affected (dev-only)
- Diff is 4 lines — regenerated under Node 24 / npm 11.16 to match CI and avoid unrelated lockfile metadata churn

## Testing
- [x] Tests pass locally with `npm test`
- [x] New and existing unit tests pass locally with my changes

Full CI suite run locally on Node 24.18.1:

| Step | Result |
| --- | --- |
| `npm audit --audit-level moderate` | 0 vulnerabilities (exit 0) |
| `npm run lint` | clean |
| `npx tsc --noEmit` | clean |
| `npm run build` | success |
| `npm run test:coverage` | 10 files, 155 tests passed — 97.01% stmts |
| `npx prettier --check` | all files match style |
| `npx depcheck` | no depcheck issue |

## Code Quality
- [x] My changes generate no new warnings
- [x] ESLint passes with no errors

## Additional Notes
No source files changed — this is purely a transitive dev-dependency bump in the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)