### PR TITLE
fix: read CLI version from package.json instead of a hardcoded string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,14 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import { JSDOM } from 'jsdom';
 import { createScraper } from './factory.js';
+import { readPackageVersion } from './version.js';
 
 const program = new Command();
 
 program
   .name('glypto')
   .description('A CLI tool for scraping webpage metadata')
-  .version('1.0.0');
+  .version(readPackageVersion());
 
 program
   .command('scrape')

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Reads the package version from package.json at runtime.
+ *
+ * The version is deliberately not duplicated in source: a hardcoded string
+ * silently drifts from the released version (see issue #87). npm always
+ * includes package.json in the published tarball regardless of the `files`
+ * allowlist, so it is available at runtime.
+ *
+ * `../package.json` resolves correctly from every entry path because both
+ * `src/` and `dist/` sit one level below the package root:
+ *
+ * - `src/version.ts`  via tsx  -> <root>/package.json
+ * - `dist/version.js` via node -> <root>/package.json
+ * - a global install          -> <prefix>/node_modules/glypto/package.json
+ *
+ * `import.meta.dirname` is used rather than `new URL('../', import.meta.url)`
+ * because the global `URL` is not always Node's: under a jsdom test
+ * environment it resolves to jsdom's subclass, which rejects a relative
+ * reference against a `file:` base.
+ */
+export function readPackageVersion(): string {
+  const packageJsonPath = join(import.meta.dirname, '..', 'package.json');
+
+  return parsePackageVersion(
+    readFileSync(packageJsonPath, 'utf8'),
+    packageJsonPath
+  );
+}
+
+/**
+ * Extracts and validates the `version` field from package.json contents.
+ *
+ * Split out from {@link readPackageVersion} so the validation is reachable in
+ * tests without mocking the filesystem. Internal — not part of the public API
+ * surface in `exports.ts`.
+ */
+export function parsePackageVersion(contents: string, source: string): string {
+  const parsed: unknown = JSON.parse(contents);
+
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !('version' in parsed) ||
+    typeof parsed.version !== 'string'
+  ) {
+    throw new Error(`Unable to read "version" from ${source}`);
+  }
+
+  return parsed.version;
+}

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parsePackageVersion, readPackageVersion } from '../src/version.js';
+
+const repoRoot = join(import.meta.dirname, '..');
+const packageVersion = JSON.parse(
+  readFileSync(join(repoRoot, 'package.json'), 'utf8')
+).version as string;
+
+const distEntry = join(repoRoot, 'dist', 'index.js');
+const srcEntry = join(repoRoot, 'src', 'index.ts');
+
+function runCli(args: string[], nodeArgs: string[] = []): string {
+  return execFileSync(process.execPath, [...nodeArgs, ...args], {
+    encoding: 'utf8',
+    cwd: repoRoot,
+  }).trim();
+}
+
+describe('readPackageVersion', () => {
+  it('returns the version declared in package.json', () => {
+    expect(readPackageVersion()).toBe(packageVersion);
+  });
+
+  it('returns a valid semver string', () => {
+    expect(readPackageVersion()).toMatch(/^\d+\.\d+\.\d+(?:[-+].+)?$/);
+  });
+
+  it('does not return the placeholder that shipped in v0.1.0-v0.2.1', () => {
+    // Regression guard for issue #87: the CLI hardcoded '1.0.0' from the
+    // initial commit, so every release reported a version it was not.
+    expect(readPackageVersion()).not.toBe('1.0.0');
+  });
+});
+
+describe('parsePackageVersion', () => {
+  it('extracts the version field', () => {
+    expect(parsePackageVersion('{"version":"1.2.3"}', 'pkg')).toBe('1.2.3');
+  });
+
+  it.each([
+    ['a missing version field', '{"name":"glypto"}'],
+    ['a non-string version', '{"version":123}'],
+    ['a null document', 'null'],
+    ['a non-object document', '"glypto"'],
+  ])('throws on %s', (_label, contents) => {
+    expect(() => parsePackageVersion(contents, '/path/package.json')).toThrow(
+      'Unable to read "version" from /path/package.json'
+    );
+  });
+
+  it('propagates malformed JSON', () => {
+    expect(() => parsePackageVersion('{not json', 'pkg')).toThrow();
+  });
+});
+
+describe('glypto --version', () => {
+  it('reports the package version when run from source (npm run dev)', () => {
+    expect(runCli([srcEntry, '--version'], ['--import', 'tsx'])).toBe(
+      packageVersion
+    );
+  });
+
+  // The build runs before tests in CI, but `npm run test` on its own does not
+  // produce dist/, so this only asserts when there is something to assert on.
+  it.skipIf(!existsSync(distEntry))(
+    'reports the package version when run from dist (npm start)',
+    () => {
+      expect(runCli([distEntry, '--version'])).toBe(packageVersion);
+    }
+  );
+});


### PR DESCRIPTION
Closes #87.

## Description

`src/index.ts` hardcoded `.version('1.0.0')` from the initial commit (74aec49), so `glypto --version` reported `1.0.0` regardless of what was installed. Every release to date shipped it wrong:

| Tag | `package.json` | `--version` reported |
| --- | --- | --- |
| v0.1.0 | 0.1.0 | `1.0.0` |
| v0.1.1 | 0.1.1 | `1.0.0` |
| v0.2.0 | 0.2.0 | `1.0.0` |
| v0.2.1 | 0.2.1 | `1.0.0` |

The version now comes from `package.json` at runtime. npm always includes `package.json` in the published tarball regardless of the `files` allowlist, and `../package.json` resolves from every entry path because `src/` and `dist/` both sit one level below the package root.

## Changes Made

- **`src/version.ts`** (new): `readPackageVersion()` plus a `parsePackageVersion()` helper
- **`src/index.ts`**: `.version('1.0.0')` → `.version(readPackageVersion())`
- **`test/version.test.ts`** (new): 11 tests covering the helper, its validation branches, and the CLI through both entry paths

Neither new function is re-exported from `exports.ts` — both stay internal, so the public API surface is unchanged.

## Two implementation notes worth a reviewer's attention

**1. `import.meta.dirname`, not `new URL('../', import.meta.url)`.**

The `new URL` form is the obvious idiom and it is what #87 suggested, but it fails under this repo's test setup. `vitest.config.ts` sets `environment: 'jsdom'`, so the global `URL` is jsdom's subclass rather than Node's, and it rejects a relative reference against a `file:` base:

```
TypeError: Invalid URL
 ❯ test/version.test.ts:7:18
      7| const repoRoot = new URL('../', import.meta.url);
```

I hit this on the first run. `import.meta.dirname` with `node:path` sidesteps the global entirely and behaves identically across tsx, node, and jsdom. There is a comment in `version.ts` recording why, so nobody "simplifies" it back.

**2. Validation is split into `parsePackageVersion(contents, source)`.**

This keeps the malformed-input branch reachable from tests without mocking `node:fs`. It is the difference between `version.ts` sitting at 85.71% coverage and at 100%.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

All three entry paths from #87's acceptance criteria are verified, the first two as automated tests and the third by hand:

| Path | Command | Result |
| --- | --- | --- |
| Source (tsx) | `node --import tsx src/index.ts --version` | `0.2.1` — asserted in test |
| Built | `node dist/index.js --version` | `0.2.1` — asserted in test |
| Global install | `npm pack` → install into an isolated prefix → `glypto --version` | `0.2.1` — verified manually |
| `bin/glypto` | `./bin/glypto --version` | `0.2.1` |

The dist assertion uses `it.skipIf(!existsSync(distEntry))`. CI builds before testing so it runs there, but `npm run test` on its own does not produce `dist/` — and the Dependabot auto-merge workflow runs exactly that, so an unconditional assertion would have broken every Dependabot PR. Verified in both states: 5 passed with `dist/` present, 4 passed + 1 skipped with it removed.

Full suite on Node 24.18.1 — lint, `tsc --noEmit`, build, prettier, `npm audit` all clean:

```
Test Files  11 passed (11)
     Tests  166 passed (166)      # was 155
```

Coverage rises from 97.01% to 97.12% statements; `version.ts` is at 100% across all columns.

## Code Quality
- [x] My changes generate no new warnings
- [x] ESLint passes with no errors
- [x] I have added tests that prove my fix is effective

## Notes

`src/index.ts` was the only source file with no test — `vitest.config.ts` excludes it from coverage as "CLI entry points (covered by integration testing if needed)". That gap is why this survived four releases, and it is also why the recent chalk 5 → 6 major bump (#83) passed CI without anything verifying the CLI still renders. The new spawn-based tests close it for `--version`; the `scrape` command remains untested.

With this merged, the pending release becomes a **minor (`0.3.0`)** rather than a patch, since `--version` output is a user-visible CLI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)