### PR TITLE
release: v0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glypto",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glypto",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glypto",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "type": "module",
   "main": "dist/exports.js",
   "types": "dist/exports.d.ts",


### PR DESCRIPTION
Bumps `package.json` **0.2.1 → 0.3.0**. Merging this unblocks tagging `v0.3.0`, which triggers `release.yml` to publish to npm.

CI must be green before merge.

## Why minor rather than patch

`glypto --version` reported a hardcoded `1.0.0` in every prior release; #88 made it read from `package.json`. That is a user-visible CLI behavior change, which earns the minor. The dependency work alone would have been `0.2.2`.

## What's in this release

| PR | Change | User-visible |
| --- | --- | --- |
| #88 | `--version` reads from `package.json` instead of hardcoded `1.0.0` | **yes** |
| #83 | chalk `^5.6.2` → `^6.0.0` (runtime dep, CLI-only) | no |
| #84 | brace-expansion → 5.0.9, clearing two high-severity DoS advisories | no |
| #86 | Node 24 pins, `docs/dependencies.md`, Lockfile Guard CI job | no |
| #79, #80, #81, #82 | dev dependency and GitHub Actions bumps | no |

`v0.3.0` will be the first release whose `--version` reports the truth.

## Verification

- Lockfile diff is version-only (regenerated under Node 24.18.1 / npm 11.16.0); libc guard self-check passes 10 → 10
- `./bin/glypto --version` reports `0.3.0` with no code change — the tests added in #88 track `package.json` automatically
- 166 tests pass across 11 files at the bumped version

🤖 Generated with [Claude Code](https://claude.com/claude-code)